### PR TITLE
Migrate the nuage amqp client to `qpid_proton` gem version 0.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem "qpid_proton", "~>0.18"
+gem "qpid_proton", "~>0.19"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
+Testing on CentOS 7 using `vagrant`:
+
+    $ vagrant up
+    # Wait a few minutes for VM provisioning to terminate
+    $ vagrant ssh
+
+    [vagrant] $ export NUAGE_AMQP_URL='amqp://amqp_host:amqp_port'
+    [vagrant] $ export NUAGE_AMQP_USERNAME='user'
+    [vagrant] $ export NUAGE_AMQP_PASSWORD='pass'
+    [vagrant] $ cd nuage_amqp_client
+    [vagrant] $ bundle exec ruby nuage_amqp_client.rb
+
+    # If you would like to debug the damn thing, run
+    [vagrant] $ PN_TRACE_FRM=1 bundle exec ruby nuage_amqp_client.rb
+
+Manual setup:
+
 ```
-# Install SASL packages (no need for devel versions)
-$ yum install cyrus-sasl cyrus-sasl-plain
-
-# Install swig to allow generation of Ruby bindings
-$ yum install swig
-
-# Install Qpid proton development package (EPEL is required)
+# Install Qpid proton development package (EPEL is required) and dependencies
 $ curl https://copr.fedorainfracloud.org/coprs/simaishi/test/repo/epel-7/simaishi-test-epel-7.repo | sudo tee /etc/yum.repos.d/qpid-proton.repo
-$ yum install qpid-proton-c-devel
+$ sudo yum install -y qpid-proton-c-devel cyrus-sasl cyrus-sasl-plain
 
 # Install the required gem
 $ bundle install

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ $ yum install cyrus-sasl cyrus-sasl-plain
 $ yum install swig
 
 # Install Qpid proton development package (EPEL is required)
-$ rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+$ curl https://copr.fedorainfracloud.org/coprs/simaishi/test/repo/epel-7/simaishi-test-epel-7.repo | sudo tee /etc/yum.repos.d/qpid-proton.repo
 $ yum install qpid-proton-c-devel
 
 # Install the required gem
 $ bundle install
 
 # Export AMQP access point into environment
-$ export NUAGE_AMQP='amqp://user:pass@amqp_host:amqp_port'
+$ export NUAGE_AMQP_URL='amqp://amqp_host:amqp_port'
+$ export NUAGE_AMQP_USERNAME='user'
+$ export NUAGE_AMQP_PASSWORD='pass'
 
 # Run the script
 $ bundle exec ruby nuage_amqp_client.rb

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,26 @@
+$root = <<SCRIPT
+curl https://copr.fedorainfracloud.org/coprs/simaishi/test/repo/epel-7/simaishi-test-epel-7.repo > /etc/yum.repos.d/qpid-proton.repo
+yum install -y qpid-proton-c-devel git gcc openssl-devel readline-devel zlib-devel cyrus-sasl cyrus-sasl-plain
+SCRIPT
+
+$user = <<SCRIPT
+git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
+echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
+. ~/.bash_profile
+mkdir -p "$(rbenv root)"/plugins
+git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+rbenv install 2.4.3
+
+git clone https://github.com/gberginc/nuage_amqp_client.git
+cd nuage_amqp_client
+rbenv local 2.4.3
+gem install bundler
+bundle install
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
+  config.vm.provision "shell", inline: $root
+  config.vm.provision "shell", inline: $user, privileged: false
+end


### PR DESCRIPTION
This pull request contains two commits:

  * first commit does minimal changes to the client in order to get it working with the `qpid_proton` gem version 0.19 and
  * second commit adds a vagrant file that makes it possible to setup CentOS-based test environment using single vagrant call.

Currently, client requires custom rpm from copr repo to work, but this should sort itself out when the latest version of `qpid-proton` packages hits the EPEL repo.